### PR TITLE
6 event system

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,3 +1,4 @@
+import { EventManagerService } from './events/event-manager.service';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { MaterialModule } from '@angular/material';
@@ -19,6 +20,7 @@ import { AppComponent } from './app.component';
     AppRoutingModule,
     MaterialModule,
   ],
+  providers: [EventManagerService],
   bootstrap: [AppComponent],
 })
 export class AppModule { }

--- a/src/app/events/event-manager.service.spec.ts
+++ b/src/app/events/event-manager.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { EventManagerService } from './event-manager.service';
+
+describe('EventManagerService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [EventManagerService]
+    });
+  });
+
+  it('should ...', inject([EventManagerService], (service: EventManagerService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/events/event-manager.service.ts
+++ b/src/app/events/event-manager.service.ts
@@ -1,0 +1,34 @@
+import { DmEvent, DmEventType } from './event';
+import { EventEmitter, Injectable } from '@angular/core';
+
+@Injectable()
+export class EventManagerService {
+
+  private eventListeners: Map<DmEventType,EventEmitter<DmEvent>>;
+
+  constructor() {
+    this.eventListeners = new Map();
+  }
+
+  subscribe(eventType: DmEventType, callback: (payload: DmEvent) => void): any {
+    let eventListener = this.eventListeners.get(eventType);
+
+    if (!eventListener) {
+      eventListener = new EventEmitter<DmEvent>();
+      this.eventListeners.set(eventType, eventListener);
+    }
+
+    return eventListener.subscribe(callback);
+  }
+
+  publish(eventType: DmEventType, payload: DmEvent): void {
+    let eventListener = this.eventListeners.get(eventType);
+
+    if (!eventListener) {
+      console.warn(`No listeners for event ${eventType.toString}`);
+      return;
+    }
+
+    eventListener.emit(payload);
+  }
+}

--- a/src/app/events/event-manager.service.ts
+++ b/src/app/events/event-manager.service.ts
@@ -25,7 +25,7 @@ export class EventManagerService {
     let eventListener = this.eventListeners.get(eventType);
 
     if (!eventListener) {
-      console.warn(`No listeners for event ${eventType.toString}`);
+      console.warn(`No listeners for event ${DmEventType[eventType]}`);
       return;
     }
 

--- a/src/app/events/event.ts
+++ b/src/app/events/event.ts
@@ -1,0 +1,25 @@
+export enum DmEventType {
+  SEARCH,
+  OTHER,
+}
+
+export interface DmSearchEvent {
+  type: DmEventType.SEARCH;
+  x: number;
+  y: number;
+}
+
+export interface DmOtherEvent {
+  type: DmEventType.OTHER;
+  z: number;
+}
+
+export type DmEvent = DmSearchEvent | DmOtherEvent;
+
+export function eventCastingAdapter<T extends DmEvent>(type: DmEventType, event: DmEvent): T {
+  if (event.type === type) {
+    return event as T;
+  }
+
+  throw `Event type ${event.type} does not match requested type ${type}`;
+}

--- a/src/app/events/event.ts
+++ b/src/app/events/event.ts
@@ -1,3 +1,4 @@
+import { SearchResult } from '../tools/search/search-result';
 export enum DmEventType {
   SEARCH,
   OTHER,
@@ -5,8 +6,7 @@ export enum DmEventType {
 
 export interface DmSearchEvent {
   type: DmEventType.SEARCH;
-  x: number;
-  y: number;
+  searchResult: SearchResult;
 }
 
 export interface DmOtherEvent {

--- a/src/app/events/event.ts
+++ b/src/app/events/event.ts
@@ -21,5 +21,5 @@ export function eventCastingAdapter<T extends DmEvent>(type: DmEventType, event:
     return event as T;
   }
 
-  throw `Event type ${event.type} does not match requested type ${type}`;
+  throw `Event type ${DmEventType[event.type]} does not match requested type ${DmEventType[type]}`;
 }

--- a/src/app/map/map.service.ts
+++ b/src/app/map/map.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnInit } from '@angular/core';
+import { Injectable } from '@angular/core';
 
 // import { Observable } from 'rxjs/Observable';
 // import 'rxjs/add/observable/of';
@@ -229,9 +229,4 @@ export class MapService implements OnInit {
 
     return layers;
   }
-
-  ngOnInit() {
-    // this.maps = new Map();
-  }
-
 }

--- a/src/app/map/map.service.ts
+++ b/src/app/map/map.service.ts
@@ -1,3 +1,5 @@
+import { DmEventType, DmSearchEvent, eventCastingAdapter } from '../events/event';
+import { EventManagerService } from '../events/event-manager.service';
 import { Injectable } from '@angular/core';
 
 // import { Observable } from 'rxjs/Observable';
@@ -38,14 +40,19 @@ proj4.defs('EPSG:27700', '+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717' +
 proj.setProj4(proj4);
 
 @Injectable()
-export class MapService implements OnInit {
+export class MapService {
 
   private maps: Map<string, OlMap>;
 
-  constructor(private configService: ConfigService) {
+  constructor(private configService: ConfigService, private eventManager: EventManagerService) {
               // private notificationsService: NotificationsService) {
     // TODO
     this.maps = new Map();
+
+    this.eventManager.subscribe(DmEventType.SEARCH, (e) => {
+      let result = eventCastingAdapter<DmSearchEvent>(e.type, e);
+      this.setCenter(result.searchResult.point, result.searchResult.zoomLevel);
+    });
   }
 
   createMap(name: string, collectionId: string) {

--- a/src/app/map/map.service.ts
+++ b/src/app/map/map.service.ts
@@ -17,12 +17,14 @@ import AttributionControl from 'ol/control/attribution';
 
 import Tile from 'ol/layer/tile';
 import TileWMS from 'ol/source/tilewms';
-import Vector from 'ol/source/vector';
+import VectorSource from 'ol/source/vector';
+import VectorLayer from 'ol/layer/vector';
 import Extent from 'ol/extent';
 import Coordinate from 'ol/coordinate';
 import Feature from 'ol/feature';
-import geom from 'ol/geom/geometry';
-import style from 'ol/style';
+import Point from 'ol/geom/point';
+import Style from 'ol/style/style';
+import Icon from 'ol/style/icon';
 import Overlay from 'ol/overlay';
 import Attribution from 'ol/attribution';
 
@@ -118,14 +120,14 @@ export class MapService implements OnInit {
 
   addMarker(position: Coordinate) {
     let iconFeature = new Feature({
-      geometry: new geom.Point(position),
+      geometry: new Point(position),
       name: 'Null Island',
       population: 4000,
       rainfall: 500,
     });
 
-    let iconStyle = new style.Style({
-      image: new style.Icon(/** @type {olx.style.IconOptions} */ ({
+    let iconStyle = new Style({
+      image: new Icon(/** @type {olx.style.IconOptions} */ ({
         anchor: [0.5, 46],
         anchorXUnits: 'fraction',
         anchorYUnits: 'pixels',
@@ -137,11 +139,11 @@ export class MapService implements OnInit {
 
     iconFeature.setStyle(iconStyle);
 
-    let vectorSource = new Vector({
+    let vectorSource = new VectorSource({
       features: [iconFeature],
     });
 
-    let vectorLayer = new Vector({
+    let vectorLayer = new VectorLayer({
       source: vectorSource,
     });
     let map = this.maps.get('mainmap');

--- a/src/app/tools/search/search.component.ts
+++ b/src/app/tools/search/search.component.ts
@@ -1,10 +1,11 @@
+import { DmEventType } from '../../events/event';
+import { EventManagerService } from '../../events/event-manager.service';
 import { Component, OnInit } from '@angular/core';
 import {
   FormBuilder, FormGroup, Validators,
   // FormBuilder, FormGroup, FormControl, FormControlName, Validators,
 } from '@angular/forms';
 
-import { MapService } from '../../map/map.service';
 import { NotificationsService } from 'angular2-notifications';
 import { SearchService } from './search.service';
 import { SearchResult } from './search-result';
@@ -24,7 +25,7 @@ export class SearchComponent implements OnInit {
 
   constructor(private fb: FormBuilder,
               private searchService: SearchService,
-              private mapService: MapService,
+              private eventManager: EventManagerService,
               private notificationsService: NotificationsService) { }
 
   search() {
@@ -50,7 +51,7 @@ export class SearchComponent implements OnInit {
 
   selectResult(result: SearchResult) {
     console.log('Search Result: ', result);
-    this.mapService.setCenter(result.point, result.zoomLevel);
+    this.eventManager.publish(DmEventType.SEARCH, { type: DmEventType.SEARCH, searchResult: result });
   }
 
   /**


### PR DESCRIPTION
This PR adds a global event manager. I've added two sample events, SEARCH and OTHER which just shows how to make extra events at the moment.

The code is type safe in the event callbacks by doing `let result = eventCastingAdapter<DmSearchEvent>(e.type, e);` which casts the event to the specified type and type safe on `publish`. Unfortunately it doesn't check if you publish a `SEARCH` event that the payload type is `DmSearchEvent`.

This should resolve #6 