### PR TITLE
Fixes #6 - Improve type safety of event system:

### DIFF
--- a/src/app/events/event-manager.service.ts
+++ b/src/app/events/event-manager.service.ts
@@ -10,22 +10,23 @@ export class EventManagerService {
     this.eventListeners = new Map();
   }
 
-  subscribe(eventType: DmEventType, callback: (payload: DmEvent) => void): any {
-    let eventListener = this.eventListeners.get(eventType);
+  subscribe<T extends DmEvent>(eventType: { new(): T }, callback: (payload: T) => void): any {
+    let eventTypeKey = new eventType().type;
 
+    let eventListener = this.eventListeners.get(eventTypeKey);
     if (!eventListener) {
       eventListener = new EventEmitter<DmEvent>();
-      this.eventListeners.set(eventType, eventListener);
+      this.eventListeners.set(eventTypeKey, eventListener);
     }
 
     return eventListener.subscribe(callback);
   }
 
-  publish(eventType: DmEventType, payload: DmEvent): void {
-    let eventListener = this.eventListeners.get(eventType);
+  publish(payload: DmEvent): void {
+    let eventListener = this.eventListeners.get(payload.type);
 
     if (!eventListener) {
-      console.warn(`No listeners for event ${DmEventType[eventType]}`);
+      console.warn(`No listeners for event ${DmEventType[payload.type]}`);
       return;
     }
 

--- a/src/app/events/event.ts
+++ b/src/app/events/event.ts
@@ -4,22 +4,20 @@ export enum DmEventType {
   OTHER,
 }
 
-export interface DmSearchEvent {
+export class DmSearchEvent {
   type: DmEventType.SEARCH;
   searchResult: SearchResult;
+  constructor() {
+    this.type = DmEventType.SEARCH;
+  }
 }
 
-export interface DmOtherEvent {
+export class DmOtherEvent {
   type: DmEventType.OTHER;
   z: number;
+  constructor() {
+    this.type = DmEventType.OTHER;
+  }
 }
 
 export type DmEvent = DmSearchEvent | DmOtherEvent;
-
-export function eventCastingAdapter<T extends DmEvent>(type: DmEventType, event: DmEvent): T {
-  if (event.type === type) {
-    return event as T;
-  }
-
-  throw `Event type ${DmEventType[event.type]} does not match requested type ${DmEventType[type]}`;
-}

--- a/src/app/map/map.service.ts
+++ b/src/app/map/map.service.ts
@@ -1,4 +1,4 @@
-import { DmEventType, DmSearchEvent, eventCastingAdapter } from '../events/event';
+import { DmSearchEvent } from '../events/event';
 import { EventManagerService } from '../events/event-manager.service';
 import { Injectable } from '@angular/core';
 
@@ -49,9 +49,8 @@ export class MapService {
     // TODO
     this.maps = new Map();
 
-    this.eventManager.subscribe(DmEventType.SEARCH, (e) => {
-      let result = eventCastingAdapter<DmSearchEvent>(e.type, e);
-      this.setCenter(result.searchResult.point, result.searchResult.zoomLevel);
+    this.eventManager.subscribe<DmSearchEvent>(DmSearchEvent, (e) => {
+      this.setCenter(e.searchResult.point, e.searchResult.zoomLevel);
     });
   }
 

--- a/src/app/tools/search/search.component.ts
+++ b/src/app/tools/search/search.component.ts
@@ -51,7 +51,7 @@ export class SearchComponent implements OnInit {
 
   selectResult(result: SearchResult) {
     console.log('Search Result: ', result);
-    this.eventManager.publish(DmEventType.SEARCH, { type: DmEventType.SEARCH, searchResult: result });
+    this.eventManager.publish({ type: DmEventType.SEARCH, searchResult: result });
   }
 
   /**


### PR DESCRIPTION
  * Not using discriminated union types any more. Use actual classes
    with a constructor that allows us to get the type information of the
    class.

Improves typing when subscribing to an event. The event type isn't required when passing parameters to the pub/sub methods. Instead generics help figure out typing. This saves calling the casting adapter function when inside a subscription callback.

Since Typescript, like Java, implements generics using type erasure we can't get the type of a `T` at runtime. Instead, we pass a reference to the class as a parameter as well. This works by calling `new` on the supplied class which initialises the event type property in the class. This property is used in the EventManager `Map`.

The downside is a bit of extra code in each event definition but the upside is improved typing. From the API point of view, it looks like the events are being subbed based on event type, even if that's not actually what happens under the scenes.