### PR TITLE
IssueID#18684 - Split map config from client config:

### DIFF
--- a/src/app/client/clients/geology.config.ts
+++ b/src/app/client/clients/geology.config.ts
@@ -3,34 +3,14 @@ import { AnnotationsComponent } from '../../sidebar/components/common/annotation
 import { JidiPreviewComponent } from '../../sidebar/components/geology/jidi-preview/jidi-preview.component';
 import { OverviewMapComponent } from '../../sidebar/components/common/overview-map/overview-map.component';
 import { FileUploadComponent } from '../../sidebar/components/common/file-upload/file-upload.component';
-import { MapConfig } from '../../config/map';
+import { ClientConfig } from '../../config/client-config';
 import { BasemapsButtonComponent } from '../../tools/basemaps/basemaps-button.component';
 import { PrintComponent } from '../../tools/print/print.component';
 import { QueryComponent } from '../../tools/query/query.component';
 import { SearchComponent } from '../../tools/search/search.component';
 
-export const GEOLOGY_CONFIG: MapConfig = {
+export const GEOLOGY_CONFIG: ClientConfig = {
   id: 'geology',
-  extent: [0, 0, 700000, 1300000],
-  resolutions: [1600, 800, 400, 200, 100, 50, 25, 10, 5, 2.5, 1, 0.5, 0.25, 0.125, 0.0625],
-  center: [33600, 67500],
-  crs: {
-    code: 'EPSG:27700',
-    proj4: `+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000
-            +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489
-            +units=m +no_defs`,
-  },
-  layers: [{
-    type: 'WMS',
-    url: 'https://map.bgs.ac.uk/arcgis/services/UKSO/UKSO_BGS/MapServer/WMSServer',
-    attributions: [
-      '<p>©  <a href="http://bgs.ac.uk/data/services/soilwms.html">Contains British Geological Survey materials © NERC 2016</a></p>',
-      ' <p>Some other attribution</p>',
-    ],
-    sublayers: ['Parent.Material.European.Soil.Bureau.Description.1km'],
-    format: 'image/png',
-    opacity: 1,
-  }],
   tools: [{
     type: SearchComponent,
   }, {

--- a/src/app/client/clients/historic.config.ts
+++ b/src/app/client/clients/historic.config.ts
@@ -2,29 +2,12 @@ import { QueryComponent } from '../../tools/query/query.component';
 import { SearchComponent } from '../../tools/search/search.component';
 import { OverviewMapComponent } from '../../sidebar/components/common/overview-map/overview-map.component';
 import { FileUploadComponent } from '../../sidebar/components/common/file-upload/file-upload.component';
-import { MapConfig } from '../../config/map';
+import { ClientConfig } from '../../config/client-config';
 import { MyMapsOpenComponent } from "../../sidebar/components/common/my-maps/my-maps-open.component";
 import { PrintComponent } from '../../tools/print/print.component';
 
-export const HISTORIC_CONFIG: MapConfig = {
+export const HISTORIC_CONFIG: ClientConfig = {
   id: 'historic',
-  extent: [-3276800, -3276800, 3276800, 3276800],
-  resolutions: [1600, 800, 400, 200, 100, 50, 25, 10, 5, 2.5, 1, 0.5, 0.25, 0.125, 0.0625],
-  center: [413674, 289141],
-  crs: {
-    code: 'EPSG:27700',
-    proj4: `+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000
-            +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489
-            +units=m +no_defs`,
-  },
-  layers: [{
-    type: 'WMS',
-    url: 'http://t0.ads.astuntechnology.com/open/osopen/service?',
-    attributions: ['Astun Data Service &copy; Ordnance Survey.'],
-    sublayers: ['osopen'],
-    format: 'image/png',
-    opacity: 1,
-  }],
   tools: [{
     type: SearchComponent,
   }, {

--- a/src/app/client/clients/os.config.ts
+++ b/src/app/client/clients/os.config.ts
@@ -2,28 +2,11 @@ import { MyMapsOpenComponent } from '../../sidebar/components/common/my-maps/my-
 import { SearchComponent } from '../../tools/search/search.component';
 import { OverviewMapComponent } from '../../sidebar/components/common/overview-map/overview-map.component';
 import { FileUploadComponent } from '../../sidebar/components/common/file-upload/file-upload.component';
-import { MapConfig } from '../../config/map';
+import { ClientConfig } from '../../config/client-config';
 import { PrintComponent } from '../../tools/print/print.component';
 
-export const OS_CONFIG: MapConfig = {
+export const OS_CONFIG: ClientConfig = {
   id: 'os',
-  extent: [-3276800, -3276800, 3276800, 3276800],
-  resolutions: [1600, 800, 400, 200, 100, 50, 25, 10, 5, 2.5, 1, 0.5, 0.25, 0.125, 0.0625],
-  center: [413674, 289141],
-  crs: {
-    code: 'EPSG:27700',
-    proj4: `+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000
-            +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489
-            +units=m +no_defs`,
-  },
-  layers: [{
-    type: 'WMS',
-    url: 'http://t0.ads.astuntechnology.com/open/osopen/service?',
-    attributions: ['Astun Data Service &copy; Ordnance Survey.'],
-    sublayers: ['osopen'],
-    format: 'image/png',
-    opacity: 1,
-  }],
   tools: [{
     type: SearchComponent,
   }, {

--- a/src/app/client/clients/os2.config.ts
+++ b/src/app/client/clients/os2.config.ts
@@ -2,29 +2,12 @@ import { BasemapsButtonComponent } from '../../tools/basemaps/basemaps-button.co
 import { SearchComponent } from '../../tools/search/search.component';
 import { OverviewMapComponent } from '../../sidebar/components/common/overview-map/overview-map.component';
 import { FileUploadComponent } from '../../sidebar/components/common/file-upload/file-upload.component';
-import { MapConfig } from '../../config/map';
+import { ClientConfig } from '../../config/client-config';
 import { MyMapsOpenComponent } from "../../sidebar/components/common/my-maps/my-maps-open.component";
 import { PrintComponent } from '../../tools/print/print.component';
 
-export const OS2_CONFIG: MapConfig = {
+export const OS2_CONFIG: ClientConfig = {
   id: 'os2',
-  extent: [-3276800, -3276800, 3276800, 3276800],
-  resolutions: [1600, 800, 400, 200, 100, 50, 25, 10, 5, 2.5, 1, 0.5, 0.25, 0.125, 0.0625],
-  center: [413674, 289141],
-  crs: {
-    code: 'EPSG:27700',
-    proj4: `+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000
-            +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489
-            +units=m +no_defs`,
-  },
-  layers: [{
-    type: 'WMS',
-    url: 'http://t0.ads.astuntechnology.com/open/osopen/service?',
-    attributions: ['Astun Data Service &copy; Ordnance Survey.'],
-    sublayers: ['osopen'],
-    format: 'image/png',
-    opacity: 1,
-  }],
   tools: [{
     type: SearchComponent,
   }, {

--- a/src/app/config/client-config.ts
+++ b/src/app/config/client-config.ts
@@ -1,0 +1,17 @@
+import { Component, Type } from '@angular/core';
+
+export interface Tool {
+  type: Type<Component>;
+  tooltip?: string;
+}
+
+export interface MenuItem {
+  title: string;
+  type: Type<Component>;
+}
+
+export interface ClientConfig {
+  id: string;
+  tools: Tool[];
+  components: MenuItem[];
+}

--- a/src/app/config/config.service.spec.ts
+++ b/src/app/config/config.service.spec.ts
@@ -3,7 +3,7 @@
 import { TestBed, inject } from '@angular/core/testing';
 
 import { ConfigService } from './config.service';
-import { MapConfig } from './map';
+import { ClientConfig } from './client-config';
 
 describe('Service: Config', () => {
   beforeEach(() => {
@@ -20,7 +20,7 @@ describe('Service: Config', () => {
     expect(config).toBeDefined();
 
     // Subscribe and verify config is for OS Collection.
-    config.subscribe((coll: MapConfig) => {
+    config.subscribe((coll: ClientConfig) => {
       expect(coll.id).toEqual('os');
     });
   }));

--- a/src/app/config/config.service.ts
+++ b/src/app/config/config.service.ts
@@ -3,15 +3,15 @@ import { FactoryProvider, Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 
-import { MapConfig } from './map';
+import { ClientConfig } from './client-config';
 
 @Injectable()
 export class ConfigService {
 
-  constructor(private mapConfig: MapConfig) {
+  constructor(private mapConfig: ClientConfig) {
   }
 
-  getMapConfig(): Observable<MapConfig> {
+  getMapConfig(): Observable<ClientConfig> {
     return Observable.of(this.mapConfig);
   }
 }

--- a/src/app/map/map-config.service.ts
+++ b/src/app/map/map-config.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/observable/throw';
+
+import { MAP_CONFIG } from './map.config';
+import { MapConfig } from './map';
+
+@Injectable()
+export class MapConfigService {
+
+  constructor() {
+  }
+
+  /** 
+   * Get the configuration for the given map.
+   * 
+   * TODO: This will use a fixed client-side configuration object. This configuration
+   * is instead to be retrieved from the backend.
+   */
+  getMapConfig(mapId: string): Observable<MapConfig> {
+    const mapConfig = MAP_CONFIG[mapId];
+    if (mapConfig === undefined) {
+      return Observable.throw({
+        message: `Map ID is unknown: ${mapId}`
+      })
+    } else {
+      return Observable.of(mapConfig);
+    }
+  }
+}

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -1,4 +1,5 @@
 import { AfterViewInit, Component, ViewEncapsulation } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 
 import { MapService } from './map.service';
 
@@ -12,13 +13,15 @@ export class MapComponent implements AfterViewInit {
 
   mapname = 'mainmap';
 
-  constructor(private mapService: MapService) {
+  constructor(private mapService: MapService, private route: ActivatedRoute) {
     console.log('Creating Map Component');
   }
 
   ngAfterViewInit() {
     // Map needs to be created after the view has been initialized or the template
     // will not be properly defined i.e. map name will not have been set.
-    this.mapService.createMap(this.mapname);
+    this.route.data.subscribe( data => {
+      this.mapService.createMap(this.mapname, data.collectionId);
+    });
   }
 }

--- a/src/app/map/map.config.ts
+++ b/src/app/map/map.config.ts
@@ -1,0 +1,88 @@
+
+import { MapConfig } from './map';
+
+export const MAP_CONFIG: { [id: string]: MapConfig } = {
+  'os': {
+    id: 'os',
+    extent: [-3276800, -3276800, 3276800, 3276800],
+    resolutions: [1600, 800, 400, 200, 100, 50, 25, 10, 5, 2.5, 1, 0.5, 0.25, 0.125, 0.0625],
+    center: [413674, 289141],
+    crs: {
+      code: 'EPSG:27700',
+      proj4: `+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000
+              +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489
+              +units=m +no_defs`,
+    },
+    layers: [{
+      type: 'WMS',
+      url: 'http://t0.ads.astuntechnology.com/open/osopen/service?',
+      attributions: ['Astun Data Service &copy; Ordnance Survey.'],
+      sublayers: ['osopen'],
+      format: 'image/png',
+      opacity: 1,
+    }]
+  },
+  'os2': {
+    id: 'os2',
+    extent: [-3276800, -3276800, 3276800, 3276800],
+    resolutions: [1600, 800, 400, 200, 100, 50, 25, 10, 5, 2.5, 1, 0.5, 0.25, 0.125, 0.0625],
+    center: [413674, 289141],
+    crs: {
+      code: 'EPSG:27700',
+      proj4: `+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000
+              +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489
+              +units=m +no_defs`,
+    },
+    layers: [{
+      type: 'WMS',
+      url: 'http://t0.ads.astuntechnology.com/open/osopen/service?',
+      attributions: ['Astun Data Service &copy; Ordnance Survey.'],
+      sublayers: ['osopen'],
+      format: 'image/png',
+      opacity: 1,
+    }],
+  },
+  'geology': {
+    id: 'geology',
+    extent: [0, 0, 700000, 1300000],
+    resolutions: [1600, 800, 400, 200, 100, 50, 25, 10, 5, 2.5, 1, 0.5, 0.25, 0.125, 0.0625],
+    center: [33600, 67500],
+    crs: {
+      code: 'EPSG:27700',
+      proj4: `+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000
+              +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489
+              +units=m +no_defs`,
+    },
+    layers: [{
+      type: 'WMS',
+      url: 'https://map.bgs.ac.uk/arcgis/services/UKSO/UKSO_BGS/MapServer/WMSServer',
+      attributions: [
+        '<p>©  <a href="http://bgs.ac.uk/data/services/soilwms.html">Contains British Geological Survey materials © NERC 2016</a></p>',
+        ' <p>Some other attribution</p>',
+      ],
+      sublayers: ['Parent.Material.European.Soil.Bureau.Description.1km'],
+      format: 'image/png',
+      opacity: 1,
+    }]
+  },
+  'historic': {
+    id: 'historic',
+    extent: [-3276800, -3276800, 3276800, 3276800],
+    resolutions: [1600, 800, 400, 200, 100, 50, 25, 10, 5, 2.5, 1, 0.5, 0.25, 0.125, 0.0625],
+    center: [413674, 289141],
+    crs: {
+      code: 'EPSG:27700',
+      proj4: `+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000
+              +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489
+              +units=m +no_defs`,
+    },
+    layers: [{
+      type: 'WMS',
+      url: 'http://t0.ads.astuntechnology.com/open/osopen/service?',
+      attributions: ['Astun Data Service &copy; Ordnance Survey.'],
+      sublayers: ['osopen'],
+      format: 'image/png',
+      opacity: 1,
+    }],
+  }
+}

--- a/src/app/map/map.module.ts
+++ b/src/app/map/map.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { MapComponent } from './map.component';
+import { MapConfigService } from "./map-config.service";
 
 @NgModule({
   imports: [
@@ -9,5 +10,6 @@ import { MapComponent } from './map.component';
   ],
   declarations: [MapComponent],
   exports: [MapComponent],
+  providers: [ MapConfigService ]
 })
 export class MapModule { }

--- a/src/app/map/map.service.ts
+++ b/src/app/map/map.service.ts
@@ -29,8 +29,10 @@ import Icon from 'ol/style/icon';
 import Overlay from 'ol/overlay';
 import Attribution from 'ol/attribution';
 
-import { MapConfig, Layer } from '../config/map';
-import { ConfigService } from '../config/config.service';
+import { MapConfig, Layer } from './map';
+import { MapConfigService } from "./map-config.service";
+
+//import { ConfigService } from '../config/config.service';
 // import { NotificationsService } from '../notifications/notifications.service';
 
 proj4.defs('EPSG:27700', '+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717' +
@@ -43,7 +45,7 @@ export class MapService {
 
   private maps: Map<string, OlMap>;
 
-  constructor(private configService: ConfigService, private eventManager: EventManagerService) {
+  constructor(private mapConfigService: MapConfigService, private eventManager: EventManagerService) {
               // private notificationsService: NotificationsService) {
     // TODO
     this.maps = new Map();
@@ -53,11 +55,11 @@ export class MapService {
     });
   }
 
-  createMap(name: string) {
-    let config: MapConfig;
-    this.configService.getMapConfig().subscribe(collection => {
-      config = collection;
-      // console.log('CONFIG: ', config);
+  createMap(elementId: string, collectionId: string): void {
+    console.log('elementId: ' + elementId);
+
+    this.mapConfigService.getMapConfig(collectionId).subscribe((config: MapConfig) => {
+      console.log('CONFIG: ', config);
 
       let extent: Extent = [0, 0, 700000, 1300000];
       let projection = proj.get(config.crs.code);
@@ -80,7 +82,7 @@ export class MapService {
           new AttributionControl(),
         ]),
         layers: layers,
-        target: name,
+        target: elementId,
         view: new View({
           projection: projection,
           center: config.center, // FIXME: See above.
@@ -89,11 +91,8 @@ export class MapService {
         }),
       });
 
-      this.maps.set(name, map);
+      this.maps.set(collectionId, map);
     });
-
-    // return map;
-    // return Observable.of(map);
   }
 
   refreshMaps() {

--- a/src/app/map/map.ts
+++ b/src/app/map/map.ts
@@ -1,4 +1,4 @@
-import { Component, Type } from '@angular/core';
+
 export interface Layer {
   type: string;
   url: string;
@@ -15,16 +15,4 @@ export interface MapConfig {
   center: [number, number];
   crs: any;
   layers: Layer[];
-  tools: Tool[];
-  components: MenuItem[];
-}
-
-export interface Tool {
-  type: Type<Component>;
-  tooltip?: string;
-}
-
-export interface MenuItem {
-  title: string;
-  type: Type<Component>;
 }

--- a/src/app/sidebar/components/common/list/list.component.ts
+++ b/src/app/sidebar/components/common/list/list.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { SidebarService } from '../../../sidebar.service';
 
 import { ConfigService } from '../../../../config/config.service';
-import { MenuItem } from '../../../../config/map';
+import { MenuItem } from '../../../../config/client-config';
 
 @Component({
   templateUrl: './list.component.html',

--- a/src/app/sidebar/sidebar-item.component.ts
+++ b/src/app/sidebar/sidebar-item.component.ts
@@ -1,6 +1,6 @@
 import { ComponentRef } from '@angular/core/core';
 import { SidebarService } from './sidebar.service';
-import { MenuItem } from '../config/map';
+import { MenuItem } from '../config/client-config';
 import { Component, Type, ComponentFactoryResolver, Input, OnInit, ViewChild, ViewChildren, ViewContainerRef, QueryList } from '@angular/core';
 
 @Component({

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -1,6 +1,6 @@
 import { SidebarService } from './sidebar.service';
 import { Component, OnInit } from '@angular/core';
-import { MenuItem } from '../config/map';
+import { MenuItem } from '../config/client-config';
 
 @Component({
   selector: 'dm-sidebar-container',

--- a/src/app/sidebar/sidebar.service.ts
+++ b/src/app/sidebar/sidebar.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
-import { MenuItem } from '../config/map';
+import { MenuItem } from '../config/client-config';
 import { ListComponent } from './components/common/list/list.component';
 
 @Injectable()

--- a/src/app/tools/tool-item.component.ts
+++ b/src/app/tools/tool-item.component.ts
@@ -1,5 +1,5 @@
 import { Component, ComponentFactoryResolver, Input, OnInit, ViewChild, ViewContainerRef } from '@angular/core';
-import { Tool } from '../config/map';
+import { Tool } from '../config/client-config';
 
 @Component({
   selector: 'dm-tool-item',

--- a/src/app/tools/toolbar.component.ts
+++ b/src/app/tools/toolbar.component.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from '@angular/core';
 import { Component, OnInit, Output } from '@angular/core';
 
 import { ConfigService } from '../config/config.service';
-import { Tool } from '../config/map';
+import { Tool } from '../config/client-config';
 
 @Component({
   selector: 'dm-toolbar',


### PR DESCRIPTION
Split the existing client side configuration into two: a client config for
specifying interface components and a separate map config.

The map config is loaded via a service (map-config.service) which is currently
hardcoded: this will be changed to retrieve the data from the server in a later
commit.

The map.component now also gets the collection ID via the ActivatedRoute's
data.collectionId property, which is used to retrieve the correct map
configuration.

Redmine issue: https://redmine.edina.ac.uk/issues/18684