### PR TITLE
18684 map config revised

### DIFF
--- a/proxy/api/mapconfig.js
+++ b/proxy/api/mapconfig.js
@@ -1,0 +1,105 @@
+'use strict';
+
+let mapConfig = {
+  'os': {
+    id: 'os',
+    extent: [-3276800, -3276800, 3276800, 3276800],
+    resolutions: [1600, 800, 400, 200, 100, 50, 25, 10, 5, 2.5, 1, 0.5, 0.25, 0.125, 0.0625],
+    center: [413674, 289141],
+    crs: {
+      code: 'EPSG:27700',
+      proj4: `+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000
+              +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489
+              +units=m +no_defs`,
+    },
+    layers: [{
+      type: 'WMS',
+      url: 'http://t0.ads.astuntechnology.com/open/osopen/service?',
+      attributions: ['Astun Data Service &copy; Ordnance Survey.'],
+      sublayers: ['osopen'],
+      format: 'image/png',
+      opacity: 1,
+    }]
+  },
+  'os2': {
+    id: 'os2',
+    extent: [-3276800, -3276800, 3276800, 3276800],
+    resolutions: [1600, 800, 400, 200, 100, 50, 25, 10, 5, 2.5, 1, 0.5, 0.25, 0.125, 0.0625],
+    center: [413674, 289141],
+    crs: {
+      code: 'EPSG:27700',
+      proj4: `+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000
+              +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489
+              +units=m +no_defs`,
+    },
+    layers: [{
+      type: 'WMS',
+      url: 'http://t0.ads.astuntechnology.com/open/osopen/service?',
+      attributions: ['Astun Data Service &copy; Ordnance Survey.'],
+      sublayers: ['osopen'],
+      format: 'image/png',
+      opacity: 1,
+    }],
+  },
+  'geology': {
+    id: 'geology',
+    extent: [0, 0, 700000, 1300000],
+    resolutions: [1600, 800, 400, 200, 100, 50, 25, 10, 5, 2.5, 1, 0.5, 0.25, 0.125, 0.0625],
+    center: [33600, 67500],
+    crs: {
+      code: 'EPSG:27700',
+      proj4: `+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000
+              +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489
+              +units=m +no_defs`,
+    },
+    layers: [{
+      type: 'WMS',
+      url: 'https://map.bgs.ac.uk/arcgis/services/UKSO/UKSO_BGS/MapServer/WMSServer',
+      attributions: [
+        '<p>©  <a href="http://bgs.ac.uk/data/services/soilwms.html">Contains British Geological Survey materials © NERC 2016</a></p>',
+        ' <p>Some other attribution</p>',
+      ],
+      sublayers: ['Parent.Material.European.Soil.Bureau.Description.1km'],
+      format: 'image/png',
+      opacity: 1,
+    }]
+  },
+  'historic': {
+    is: 'historic',
+    extent: [-3276800, -3276800, 3276800, 3276800],
+    resolutions: [1600, 800, 400, 200, 100, 50, 25, 10, 5, 2.5, 1, 0.5, 0.25, 0.125, 0.0625],
+    center: [413674, 289141],
+    crs: {
+      code: 'EPSG:27700',
+      proj4: `+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000
+              +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489
+              +units=m +no_defs`,
+    },
+    layers: [{
+      type: 'WMS',
+      url: 'http://t0.ads.astuntechnology.com/open/osopen/service?',
+      attributions: ['Astun Data Service &copy; Ordnance Survey.'],
+      sublayers: ['osopen'],
+      format: 'image/png',
+      opacity: 1,
+    }],
+  }
+}
+
+let getMapConfig = (req, res) =>{
+  let mapId = req.params.mapId
+  console.log('getMapConfig for: ' + mapId)
+  let config = mapConfig[mapId]
+  if (config !== undefined) {
+    res.json(config)
+  } else {
+    res.status(400)
+    res.json({
+      message: `Unknown mapId (${mapId})`
+    })
+  }
+}
+
+module.exports = {
+  getMapConfig
+};

--- a/proxy/proxy.js
+++ b/proxy/proxy.js
@@ -13,6 +13,7 @@ var morgan     = require('morgan');
 var search     = require('./api/search.js');
 var print      = require('./api/print.js');
 var gfi        = require('./api/gfi.js');
+var mapconfig  = require('./api/mapconfig.js');
 
 // configure app
 app.use(morgan('dev')); // log requests to the console
@@ -47,6 +48,7 @@ router.get('/', function(req, res) {
 router.get('/search', search.search);
 router.get('/gfi', gfi.gfi);
 router.route('/print').post(print.print);
+router.get('/config/map/:mapId', mapconfig.getMapConfig);
 
 // REGISTER OUR ROUTES -------------------------------
 app.use('/api', router);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,7 +3,6 @@ import { EventManagerService } from './events/event-manager.service';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { MaterialModule } from '@angular/material';
-// import { ConfigModule } from './config/config.module';
 
 // import { SimpleNotificationsModule } from 'angular2-notifications';
 
@@ -14,9 +13,6 @@ import { AppComponent } from './app.component';
 
 import { CovalentFileModule, CovalentDataTableModule } from '@covalent/core';
 import { SearchModule } from "./tools/search/search.module";
-
-// import { ConfigService } from './config/config.service';
-// import { MapConfigService } from './config/map-config.service';
 
 @NgModule({
   declarations: [
@@ -32,7 +28,7 @@ import { SearchModule } from "./tools/search/search.module";
     CovalentDataTableModule,
     BrowserAnimationsModule,
   ],
-  providers: [EventManagerService], //, ConfigService, MapConfigService],
+  providers: [EventManagerService],
   bootstrap: [AppComponent],
 })
 export class AppModule { }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { EventManagerService } from './events/event-manager.service';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { MaterialModule } from '@angular/material';
+// import { ConfigModule } from './config/config.module';
 
 // import { SimpleNotificationsModule } from 'angular2-notifications';
 
@@ -13,6 +14,9 @@ import { AppComponent } from './app.component';
 
 import { CovalentFileModule, CovalentDataTableModule } from '@covalent/core';
 import { SearchModule } from "./tools/search/search.module";
+
+// import { ConfigService } from './config/config.service';
+// import { MapConfigService } from './config/map-config.service';
 
 @NgModule({
   declarations: [
@@ -28,7 +32,7 @@ import { SearchModule } from "./tools/search/search.module";
     CovalentDataTableModule,
     BrowserAnimationsModule,
   ],
-  providers: [EventManagerService],
+  providers: [EventManagerService], //, ConfigService, MapConfigService],
   bootstrap: [AppComponent],
 })
 export class AppModule { }

--- a/src/app/client/client.module.ts
+++ b/src/app/client/client.module.ts
@@ -7,6 +7,7 @@ import { MapModule } from '../map/map.module';
 import { SidebarModule } from '../sidebar/sidebar.module';
 import { ToolsModule } from '../tools/tools.module';
 import { ClientComponent } from './client.component';
+import { ConfigModule } from '../config/config.module';
 
 @NgModule({
   imports: [
@@ -16,6 +17,7 @@ import { ClientComponent } from './client.component';
     MaterialModule,
     SidebarModule,
     ToolsModule,
+    ConfigModule
   ],
   declarations: [ClientComponent],
   exports: [ClientComponent],

--- a/src/app/client/clients/geology.config.ts
+++ b/src/app/client/clients/geology.config.ts
@@ -3,34 +3,14 @@ import { AnnotationsComponent } from '../../sidebar/components/common/annotation
 import { JidiPreviewComponent } from '../../sidebar/components/geology/jidi-preview/jidi-preview.component';
 import { OverviewMapComponent } from '../../sidebar/components/common/overview-map/overview-map.component';
 import { FileUploadComponent } from '../../sidebar/components/common/file-upload/file-upload.component';
-import { MapConfig } from '../../config/map';
+import { ClientConfig } from '../../config/map';
 import { BasemapsButtonComponent } from '../../tools/basemaps/basemaps-button.component';
 import { PrintComponent } from '../../tools/print/print.component';
 import { QueryComponent } from '../../tools/query/query.component';
 import { SearchComponent } from '../../tools/search/search.component';
 
-export const GEOLOGY_CONFIG: MapConfig = {
+export const GEOLOGY_CONFIG: ClientConfig = {
   id: 'geology',
-  extent: [0, 0, 700000, 1300000],
-  resolutions: [1600, 800, 400, 200, 100, 50, 25, 10, 5, 2.5, 1, 0.5, 0.25, 0.125, 0.0625],
-  center: [33600, 67500],
-  crs: {
-    code: 'EPSG:27700',
-    proj4: `+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000
-            +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489
-            +units=m +no_defs`,
-  },
-  layers: [{
-    type: 'WMS',
-    url: 'https://map.bgs.ac.uk/arcgis/services/UKSO/UKSO_BGS/MapServer/WMSServer',
-    attributions: [
-      '<p>©  <a href="http://bgs.ac.uk/data/services/soilwms.html">Contains British Geological Survey materials © NERC 2016</a></p>',
-      ' <p>Some other attribution</p>',
-    ],
-    sublayers: ['Parent.Material.European.Soil.Bureau.Description.1km'],
-    format: 'image/png',
-    opacity: 1,
-  }],
   tools: [{
     type: SearchComponent,
   }, {

--- a/src/app/client/clients/historic.config.ts
+++ b/src/app/client/clients/historic.config.ts
@@ -2,29 +2,12 @@ import { QueryComponent } from '../../tools/query/query.component';
 import { SearchComponent } from '../../tools/search/search.component';
 import { OverviewMapComponent } from '../../sidebar/components/common/overview-map/overview-map.component';
 import { FileUploadComponent } from '../../sidebar/components/common/file-upload/file-upload.component';
-import { MapConfig } from '../../config/map';
+import { ClientConfig } from '../../config/map';
 import { MyMapsOpenComponent } from "../../sidebar/components/common/my-maps/my-maps-open.component";
 import { PrintComponent } from '../../tools/print/print.component';
 
-export const HISTORIC_CONFIG: MapConfig = {
+export const HISTORIC_CONFIG: ClientConfig = {
   id: 'historic',
-  extent: [-3276800, -3276800, 3276800, 3276800],
-  resolutions: [1600, 800, 400, 200, 100, 50, 25, 10, 5, 2.5, 1, 0.5, 0.25, 0.125, 0.0625],
-  center: [413674, 289141],
-  crs: {
-    code: 'EPSG:27700',
-    proj4: `+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000
-            +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489
-            +units=m +no_defs`,
-  },
-  layers: [{
-    type: 'WMS',
-    url: 'http://t0.ads.astuntechnology.com/open/osopen/service?',
-    attributions: ['Astun Data Service &copy; Ordnance Survey.'],
-    sublayers: ['osopen'],
-    format: 'image/png',
-    opacity: 1,
-  }],
   tools: [{
     type: SearchComponent,
   }, {

--- a/src/app/client/clients/os.config.ts
+++ b/src/app/client/clients/os.config.ts
@@ -2,29 +2,12 @@ import { MyMapsOpenComponent } from '../../sidebar/components/common/my-maps/my-
 import { SearchComponent } from '../../tools/search/search.component';
 import { OverviewMapComponent } from '../../sidebar/components/common/overview-map/overview-map.component';
 import { FileUploadComponent } from '../../sidebar/components/common/file-upload/file-upload.component';
-import { MapConfig } from '../../config/map';
+import { ClientConfig } from '../../config/map';
 import { BasemapsButtonComponent } from '../../tools/basemaps/basemaps-button.component';
 import { PrintComponent } from '../../tools/print/print.component';
 
-export const OS_CONFIG: MapConfig = {
+export const OS_CONFIG: ClientConfig = {
   id: 'os',
-  extent: [-3276800, -3276800, 3276800, 3276800],
-  resolutions: [1600, 800, 400, 200, 100, 50, 25, 10, 5, 2.5, 1, 0.5, 0.25, 0.125, 0.0625],
-  center: [413674, 289141],
-  crs: {
-    code: 'EPSG:27700',
-    proj4: `+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000
-            +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489
-            +units=m +no_defs`,
-  },
-  layers: [{
-    type: 'WMS',
-    url: 'http://t0.ads.astuntechnology.com/open/osopen/service?',
-    attributions: ['Astun Data Service &copy; Ordnance Survey.'],
-    sublayers: ['osopen'],
-    format: 'image/png',
-    opacity: 1,
-  }],
   tools: [{
     type: SearchComponent,
   }, {

--- a/src/app/config/config.module.ts
+++ b/src/app/config/config.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core';
+import { MapConfigService } from '../config/map-config.service';
+
+@NgModule({
+  providers: [MapConfigService]
+})
+export class ConfigModule { }

--- a/src/app/config/config.service.spec.ts
+++ b/src/app/config/config.service.spec.ts
@@ -3,7 +3,7 @@
 import { TestBed, inject } from '@angular/core/testing';
 
 import { ConfigService } from './config.service';
-import { MapConfig } from './map';
+import { ClientConfig } from './map';
 
 describe('Service: Config', () => {
   beforeEach(() => {
@@ -16,11 +16,11 @@ describe('Service: Config', () => {
     expect(service).toBeTruthy();
 
     // Get Observable of OS MapConfig.
-    const config = service.getMapConfig();
+    const config = service.getClientConfig();
     expect(config).toBeDefined();
 
     // Subscribe and verify config is for OS Collection.
-    config.subscribe((coll: MapConfig) => {
+    config.subscribe((coll: ClientConfig) => {
       expect(coll.id).toEqual('os');
     });
   }));

--- a/src/app/config/config.service.ts
+++ b/src/app/config/config.service.ts
@@ -3,16 +3,16 @@ import { FactoryProvider, Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 
-import { MapConfig } from './map';
+import { ClientConfig } from './map';
 
 @Injectable()
 export class ConfigService {
 
-  constructor(private mapConfig: MapConfig) {
+  constructor(private clientConfig: ClientConfig) {
   }
 
-  getMapConfig(): Observable<MapConfig> {
-    return Observable.of(this.mapConfig);
+  getClientConfig(): Observable<ClientConfig> {
+    return Observable.of(this.clientConfig);
   }
 }
 

--- a/src/app/config/map-config.service.ts
+++ b/src/app/config/map-config.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { Http, Response } from '@angular/http';
+
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/concatMap';
+
+import { ClientConfig, MapConfig } from './map';
+import { ConfigService } from './config.service';
+
+const API = {
+  mapConfig: 'api/config/map/'
+};
+
+@Injectable()
+export class MapConfigService {
+
+  constructor(private configService: ConfigService, private http: Http) {
+  }
+
+  /** Get the configuration for current map as specified in the client config */
+  getMapConfig(): Observable<MapConfig> {
+    return this.configService.getClientConfig()
+                             .concatMap((config: ClientConfig) => {
+                                return this.http.get(API.mapConfig + config.id)
+                                                .map((res: Response) => res.json());
+                             });
+  }
+}

--- a/src/app/config/map.ts
+++ b/src/app/config/map.ts
@@ -1,4 +1,5 @@
 import { Component, Type } from '@angular/core';
+
 export interface Layer {
   type: string;
   url: string;
@@ -15,6 +16,10 @@ export interface MapConfig {
   center: [number, number];
   crs: any;
   layers: Layer[];
+}
+
+export interface ClientConfig {
+  id: string;
   tools: Tool[];
   components: MenuItem[];
 }

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -1,5 +1,6 @@
 import { AfterViewInit, Component, ViewEncapsulation } from '@angular/core';
 
+import OlMap from 'ol/map';
 import { MapService } from './map.service';
 
 @Component({
@@ -19,6 +20,8 @@ export class MapComponent implements AfterViewInit {
   ngAfterViewInit() {
     // Map needs to be created after the view has been initialized or the template
     // will not be properly defined i.e. map name will not have been set.
-    this.mapService.createMap(this.mapname);
+    this.mapService.createMap().subscribe((map: OlMap) => {
+      map.setTarget(this.mapname);
+    })
   }
 }

--- a/src/app/map/map.service.ts
+++ b/src/app/map/map.service.ts
@@ -29,8 +29,8 @@ import Icon from 'ol/style/icon';
 import Overlay from 'ol/overlay';
 import Attribution from 'ol/attribution';
 
+import { MapConfigService } from '../config/map-config.service';
 import { MapConfig, Layer } from '../config/map';
-import { ConfigService } from '../config/config.service';
 // import { NotificationsService } from '../notifications/notifications.service';
 
 proj4.defs('EPSG:27700', '+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717' +
@@ -43,7 +43,7 @@ export class MapService {
 
   private maps: Map<string, OlMap>;
 
-  constructor(private configService: ConfigService, private eventManager: EventManagerService) {
+  constructor(private mapConfigService: MapConfigService, private eventManager: EventManagerService) {
               // private notificationsService: NotificationsService) {
     // TODO
     this.maps = new Map();
@@ -54,9 +54,7 @@ export class MapService {
   }
 
   createMap(name: string) {
-    let config: MapConfig;
-    this.configService.getMapConfig().subscribe(collection => {
-      config = collection;
+    this.mapConfigService.getMapConfig().subscribe((config: MapConfig) => {
       // console.log('CONFIG: ', config);
 
       let extent: Extent = [0, 0, 700000, 1300000];
@@ -89,11 +87,8 @@ export class MapService {
         }),
       });
 
-      this.maps.set(name, map);
+      this.maps.set(config.id, map);
     });
-
-    // return map;
-    // return Observable.of(map);
   }
 
   refreshMaps() {

--- a/src/app/map/map.service.ts
+++ b/src/app/map/map.service.ts
@@ -2,8 +2,8 @@ import { DmSearchEvent } from '../events/event';
 import { EventManagerService } from '../events/event-manager.service';
 import { Injectable } from '@angular/core';
 
-// import { Observable } from 'rxjs/Observable';
-// import 'rxjs/add/observable/of';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/map';
 
 import proj4 from 'proj4';
 
@@ -53,8 +53,8 @@ export class MapService {
     });
   }
 
-  createMap(name: string) {
-    this.mapConfigService.getMapConfig().subscribe((config: MapConfig) => {
+  createMap(): Observable<OlMap> {
+    return this.mapConfigService.getMapConfig().map((config: MapConfig) => {
       // console.log('CONFIG: ', config);
 
       let extent: Extent = [0, 0, 700000, 1300000];
@@ -78,7 +78,6 @@ export class MapService {
           new AttributionControl(),
         ]),
         layers: layers,
-        target: name,
         view: new View({
           projection: projection,
           center: config.center, // FIXME: See above.
@@ -88,6 +87,7 @@ export class MapService {
       });
 
       this.maps.set(config.id, map);
+      return map;
     });
   }
 

--- a/src/app/sidebar/components/common/list/list.component.ts
+++ b/src/app/sidebar/components/common/list/list.component.ts
@@ -19,8 +19,8 @@ export class ListComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.configService.getMapConfig().subscribe(mapConfig => {
-      this.components = mapConfig.components;
+    this.configService.getClientConfig().subscribe(clientConfig => {
+      this.components = clientConfig.components;
     });
   }
 }

--- a/src/app/tools/toolbar.component.ts
+++ b/src/app/tools/toolbar.component.ts
@@ -23,8 +23,8 @@ export class ToolbarComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.configService.getMapConfig().subscribe(mapConfig => {
-      this.tools = mapConfig.tools;
+    this.configService.getClientConfig().subscribe(clientConfig => {
+      this.tools = clientConfig.tools;
     });
   }
 }


### PR DESCRIPTION
Splits map config from client config and gets the map config from the server (proxy only at this point). The format of the map config will be updated to match the required form in a later PR.

I've created a new config.module which declares the MapConfigService as a provider: it didn't seem to make sense to add this to a different module (please correct me if this is wrong). I couldn't get the app to run without the MapConfigService being declared in a provides list.

Also temporary: the createMap function at the moment returns an Observable<OlMap> rather than wrapping the OpenLayers map object.

This PR replaces the older one.

Redmine issue: https://redmine.edina.ac.uk/issues/18684